### PR TITLE
Upgrading Task Definition Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | <a name="input_organization"></a> [organization](#input\_organization) | Organization using this module. Used to prefix tags so that they are easily identified as being from your organization | `string` | n/a | yes |
 | <a name="input_product"></a> [product](#input\_product) | Tag used to group resources according to product | `string` | n/a | yes |
 | <a name="input_repo"></a> [repo](#input\_repo) | Tag used to point to the repo using this module | `string` | n/a | yes |
+| <a name="input_awslogs_driver_mode"></a> [awslogs\_driver\_mode](#input\_awslogs\_driver\_mode) | (optional) awslogs driver mode. Set this to `blocking` if you would rather have an outage than lose logs. | `string` | `"non-blocking"` | no |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | The name of the ECS Cluster this task runs in. | `string` | `null` | no |
 | <a name="input_command"></a> [command](#input\_command) | (optional) command to run in the container as an array. e.g. ["sleep", "10"]. If null, does not set a command in the task definition. | `list(string)` | `null` | no |
 | <a name="input_container_definitions"></a> [container\_definitions](#input\_container\_definitions) | (optional) JSON container definitions for task | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-cron-module?ref=1.0.0
+github.com/pbs/terraform-aws-ecs-cron-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "cron" {
-  source = "github.com/pbs/terraform-aws-ecs-cron-module?ref=1.0.0"
+  source = "github.com/pbs/terraform-aws-ecs-cron-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -41,7 +41,7 @@ module "cron" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`1.0.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -71,7 +71,7 @@ Below is automatically generated documentation on this Terraform module using [t
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cluster"></a> [cluster](#module\_cluster) | github.com/pbs/terraform-aws-ecs-cluster-module | 0.0.1 |
-| <a name="module_task"></a> [task](#module\_task) | github.com/pbs/terraform-aws-ecs-task-definition-module | 0.2.0 |
+| <a name="module_task"></a> [task](#module\_task) | github.com/pbs/terraform-aws-ecs-task-definition-module | 1.0.0 |
 
 ## Resources
 

--- a/optional-task.tf
+++ b/optional-task.tf
@@ -127,3 +127,9 @@ variable "runtime_platform" {
     cpu_architecture        = optional(string, "X86_64")
   })
 }
+
+variable "awslogs_driver_mode" {
+  description = "(optional) awslogs driver mode. Set this to `blocking` if you would rather have an outage than lose logs."
+  default     = "non-blocking"
+  type        = string
+}

--- a/task.tf
+++ b/task.tf
@@ -31,6 +31,8 @@ module "task" {
   use_xray_sidecar = var.use_xray_sidecar
   runtime_platform = var.runtime_platform
 
+  awslogs_driver_mode = var.awslogs_driver_mode
+
   organization = var.organization
   environment  = var.environment
   product      = var.product

--- a/task.tf
+++ b/task.tf
@@ -1,6 +1,6 @@
 module "task" {
   count  = var.task_def_arn == null ? 1 : 0
-  source = "github.com/pbs/terraform-aws-ecs-task-definition-module?ref=0.2.0"
+  source = "github.com/pbs/terraform-aws-ecs-task-definition-module?ref=1.0.0"
 
   image_repo = var.image_repo
   image_tag  = var.image_tag


### PR DESCRIPTION
Upgrading ECS Task Definition module.

This is a breaking change, as we are changing the default behavior of the AWS log driver to use the non-blocking mode.

If you are currently using this module, note that this update can result in loss of logs when CloudWatch Logs is inaccessible.

