### PR TITLE
Fixing a bug where the extra role policy name for a task doesn't match the task name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-ecs-cron-module?ref=2.2.0
+github.com/pbs/terraform-aws-ecs-cron-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "cron" {
-  source = "github.com/pbs/terraform-aws-ecs-cron-module?ref=2.2.0"
+  source = "github.com/pbs/terraform-aws-ecs-cron-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -41,7 +41,7 @@ module "cron" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`2.2.0`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 

--- a/task.tf
+++ b/task.tf
@@ -8,6 +8,7 @@ module "task" {
   role_policy_json       = local.role_policy_json
   extra_role_policy_json = var.extra_role_policy_json
 
+  name                     = local.name
   service_name             = local.name
   task_family              = local.task_family
   container_name           = var.container_name


### PR DESCRIPTION
As written, the current implementation accidentally disallows multiple ECS cron workers that have an extra role policy for a single product. Here's my rationale:
- The `name` of a task, if not provided as an input, defaults to `product` ([source](https://github.com/pbs/terraform-aws-ecs-task-definition-module/blob/main/locals.tf#L2)).
- The name of the extra role policy is defined based on the `name` input ([source](https://github.com/pbs/terraform-aws-ecs-task-definition-module/blob/main/security.tf#L190)).

If two un-`name`d tasks are created with the same product, it would create a conflict when creating an extra role policy for both of them (because their names would match).

This change updates the cron module to provide that `name` field, which consumers will need to provide in order to deconflict.